### PR TITLE
Fix entrypoint command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-if [ ! -e /.initialized_user ] && [ ! -z $AFP_LOGIN ] && [ ! -z $AFP_PASSWORD ] && [ ! -z $AFP_NAME ] && [ ! -z $PUID ] && [ ! -z $PGID ]; then
-    add-account -i $PUID -g $PGID $AFP_LOGIN $AFP_PASSWORD $AFP_NAME /timemachine $AFP_SIZE_LIMIT
+if [ ! -e /.initialized_user ] && [ ! -z "$AFP_LOGIN" ] && [ ! -z "$AFP_PASSWORD" ] && [ ! -z "$AFP_NAME" ] && [ ! -z $PUID ] && [ ! -z $PGID ]; then
+    add-account -i $PUID -g $PGID "$AFP_LOGIN" "$AFP_PASSWORD" "$AFP_NAME" /timemachine $AFP_SIZE_LIMIT
     touch /.initialized_user
 fi
 


### PR DESCRIPTION
Bash vars need to be surrounded by quotes when there's a chance they will have a space in them.